### PR TITLE
Fix the use of queryString on :_dbnameChanged method during the setup

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "vaadin-pouchdb",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "homepage": "https://github.com/manolo/vaadin-pouchdb",
   "main": "vaadin-pouchdb.html",
   "authors": [

--- a/vaadin-pouchdb.html
+++ b/vaadin-pouchdb.html
@@ -35,12 +35,13 @@
         notify: true
       },
       queryString: {
-        type: String
+        type: String,
+        value: ""
       }
     },
 
     observers: [
-      '_dbnameChanged(dbname)',
+      '_dbnameChanged(dbname, queryString)',
       '_remoteChanged(remote)',
       '_onDataChanged(data.*)'
     ],


### PR DESCRIPTION
The _dbnameChanged is called before the value of queryString is set in the component, so with a definition as :

<vaadin-pouchdb id="db"
      query-string="products"
      dbname="shop"
      data="{{products}}"
     ></vaadin-pouchdb>

when the _dbnameChanged method is executed the value of queryString is still undefined and therefore the component is loading all the docs of the database.

If we set a default value "" for the queryString property and we add it as a dependency for the _dbnameChanged, when it is called the property has the right value.
